### PR TITLE
Remove libdl-static from being a requirement for static gpg

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -3,22 +3,6 @@
 LOCAL_PATH:=$(call my-dir)
 gpg_local_path := $(LOCAL_PATH)
 
-#
-# build static version of libdl from bionics
-#
-
-include $(CLEAR_VARS)
-LOCAL_LDFLAGS := -Wl,--exclude-libs=libgcc.a
-# for x86, exclude libgcc_eh.a for the same reasons as above
-ifeq ($(TARGET_ARCH),x86)
-LOCAL_LDFLAGS += -Wl,--exclude-libs=libgcc_eh.a
-endif
-LOCAL_SRC_FILES:= ../../bionic/libdl/libdl.cpp
-LOCAL_MODULE:= libdl-static
-LOCAL_ADDITIONAL_DEPENDENCIES := $(LOCAL_PATH)/Android.mk
-LOCAL_ALLOW_UNDEFINED_SYMBOLS := true
-include $(BUILD_STATIC_LIBRARY)
-
 # gpg
 include $(CLEAR_VARS)
 

--- a/g10/Android.mk
+++ b/g10/Android.mk
@@ -81,7 +81,7 @@ LOCAL_CFLAGS := \
 LOCAL_CFLAGS += -DHAVE_CONFIG_H -Wno-error
 
 LOCAL_STATIC_LIBRARIES += libgpgcipher libgpgutil libgpgmpi libgpgintl libgpgcompat
-LOCAL_STATIC_LIBRARIES += libc libz libdl-static
+LOCAL_STATIC_LIBRARIES += libc libz
 
 LOCAL_MODULE:= static_gpg
 LOCAL_MODULE_CLASS := RECOVERY_EXECUTABLES


### PR DESCRIPTION
This actually is an interesting one, for some reason only on armhf the libdl static library is no longer needed in static gpg build, since external/libunwind_llvm is now built without requiring this anymore.

This will fix the ugly error with __aeabi_unwind_cpp_pr0:

```
prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/arm-linux-androideabi/bin/ld: error: /home/florian/porting/hammerhead-9.0/out/target/product/hammerhead/obj/STATIC_LIBRARIES/libunwind_llvm_intermediates/libunwind_llvm.a(Unwind-EHABI.o): multiple definition of '__aeabi_unwind_cpp_pr0'
prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/arm-linux-androideabi/bin/ld: /home/florian/porting/hammerhead-9.0/out/target/product/hammerhead/obj/STATIC_LIBRARIES/libdl-static_intermediates/libdl-static.a(libdl.o): previous definition here
```
Change-Id: I07ab588c3d08d2fb0e016adb94c646e6539b86cb